### PR TITLE
First create the editor, then init the plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,12 @@ window.DatoCmsPlugin.init((plugin) => {
   const datoClient = new SiteClient(plugin.parameters.global.apiToken)
   const main = document.createElement('main')
   let editor
-
-  initPlugin()
-
+  
   if (plugin.parameters.instance.editFunction) {
     editor = createEditor(main, code, executeComputedCode)
   }
+
+  initPlugin()
 
   createOutput(main, fieldType)
 


### PR DESCRIPTION
Hi friends! Someone spotted a problem with this awesome plugin!

When the record is opened you get:

![image(6)](https://user-images.githubusercontent.com/51573/107612045-a7482b00-6c45-11eb-8815-d2226a712165.png)

And only if you change some fields you get the computed value:

![image(7)](https://user-images.githubusercontent.com/51573/107612079-bcbd5500-6c45-11eb-9085-9fd23634be30.png)

The reason is that you init the plugin before creating the editor, so the first `executeComputedCode()` doesn't do anything :)