### PR TITLE
Feat/get field value update and disable field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-computed-fields",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-computed-fields",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-javascript": "^0.19.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datocms-plugin-computed-fields",
   "homepage": "https://github.com/voorhoede/datocms-plugin-computed-fields",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "This plugin allows to compute and define a field value based on other fields",
   "engines": {
     "node": ">=16.0.0"

--- a/src/components/RenderResults/RenderResults.tsx
+++ b/src/components/RenderResults/RenderResults.tsx
@@ -55,6 +55,11 @@ export default function CodeEditor({ value, fieldType }: Props) {
             htmlFor: 'computed-field--boolean',
             className: 'sr-only',
           }}
+          switchInputProps={{
+            disabled: true,
+            name: "computed-field--boolean",
+            value,
+          }}
         />
       )
     }
@@ -81,6 +86,7 @@ export default function CodeEditor({ value, fieldType }: Props) {
           }}
           textInputProps={{
             readOnly: true,
+            disabled: true,
             type: 'number',
           }}
         />
@@ -108,6 +114,7 @@ export default function CodeEditor({ value, fieldType }: Props) {
           }}
           textInputProps={{
             readOnly: true,
+            disabled: true,
           }}
         />
       )

--- a/src/entrypoints/FieldExtension/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension/FieldExtension.tsx
@@ -63,7 +63,7 @@ export default function FieldExtension({ ctx }: Props) {
 
   if (pluginParameters.hideField) {
     ctx.updateHeight(0)
-    return <></>
+    return null
   }
 
   return (

--- a/src/lib/executeComputedCode.ts
+++ b/src/lib/executeComputedCode.ts
@@ -5,7 +5,7 @@ const { SiteClient } = require('datocms-client')
 interface Variables {
   getUpload: (uploadId: string) => any
   getModel: (modelId: string) => any
-  getFieldValue: (object: object, fieldName: string) => string
+  getFieldValue: (object: object, fieldName: string) => any
   changedField: string | undefined
   locale: string
   datoCmsPlugin: RenderFieldExtensionCtx

--- a/src/lib/getFieldValue.ts
+++ b/src/lib/getFieldValue.ts
@@ -1,5 +1,5 @@
 import get from 'lodash/get'
 
-export default function getFieldValue(object: object, fieldName: string): string {
-  return String(get(object, fieldName))
+export default function getFieldValue(object: object, fieldName: string): any {
+  return get(object, fieldName)
 }


### PR DESCRIPTION
Makes sure the `getFieldValue` function doesn't stringify all values. (fixes https://github.com/voorhoede/datocms-plugin-computed-fields/issues/19)

Shows the field as `disabled` to make sure people know the field is generated automatically. (issue https://github.com/voorhoede/datocms-plugin-computed-fields/issues/20)