### PR TITLE
Change steps to publish

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -24,6 +24,6 @@ Before publishing this plugin, make sure:
 * you've properly compiled this project's `package.json` following the [official rules](https://www.datocms.com/docs/plugin-sdk/publishing-to-marketplace).
 
 When everything's ready:
-1. Run `npm version` with the appropiate version change.
-1. Append the related changelog changes to the version commit using `git commit --amend --no-edit`.
-1. Finally run `git push --follow-tags` to push and trigger publishing from CI.
+1. Update `changelog.md` with relevant changes and stage with `git add`.
+1. Run `npm version --force` with the appropiate version bump to include the changelog changes in the same commit.
+1. This should automatically push the commit and new version tag to trigger publishing from CI.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "cross-env PUBLIC_URL='.' react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "postversion": "git push --follow-tags"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.1.4",


### PR DESCRIPTION
The previous way did not work out because `amend` does not keep the git tag intact, note that including the changelog changes in the version commit is not necessary but a nice bonus I think. So if a dev makes a mistake not including it that's okay.