### PR TITLE
Add support for aborting execution without propagating any changes;

### DIFF
--- a/src/entrypoints/FieldExtension/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension/FieldExtension.tsx
@@ -37,7 +37,7 @@ export default function FieldExtension({ ctx }: Props) {
         codeToExecute,
         changedField
       )
-      if (fieldValue !== undefined) {
+      if (codeResult !== undefined) {
         setFieldValue(codeResult)
       }
       return codeResult

--- a/src/entrypoints/FieldExtension/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension/FieldExtension.tsx
@@ -37,7 +37,9 @@ export default function FieldExtension({ ctx }: Props) {
         codeToExecute,
         changedField
       )
-      setFieldValue(codeResult)
+      if (fieldValue !== undefined) {
+        setFieldValue(codeResult)
+      }
       return codeResult
     },
     []
@@ -54,15 +56,19 @@ export default function FieldExtension({ ctx }: Props) {
   Object.keys(differenceObject).forEach((key) => {
     if (code.includes(key) || (code.includes('thisBlock') && key.includes(fieldPathOfBlock))) {
       handleFieldValue(ctx, code, key).then((fieldValue: any) => {
-        saveFieldValue(ctx, fieldValue)
-        setFormValues(ctx.formValues)
+        if (fieldValue !== undefined) {
+          saveFieldValue(ctx, fieldValue)
+          setFormValues(ctx.formValues)
+        }
       })
     }
   })
 
   useEffect(() => {
     handleFieldValue(ctx, code).then((fieldValue: any) => {
-      saveFieldValue(ctx, fieldValue)
+      if (fieldValue !== undefined) {
+        saveFieldValue(ctx, fieldValue)
+      }
     })
 
     //eslint-disable-next-line


### PR DESCRIPTION
Enhancement idea.

When computed code modifies other fields in the model (which in turn triggers back the script) it can get unwieldy.

This adds a way to abort execution of the script without causing new computed value to re-trigger execution.

I used 'undefined' value in this PR (naturally this prevents the script from setting undefined value on the field).

What do you think?
Is 'null' better suited (or some other magic value)?