### PR TITLE
feat: add model type helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 * Return specified values
 * Use all javascript functionality
-* Get a model and an upload with an ID
+* Get a model, a model schema, and an upload with an ID
 * Have access to all fields on the page
 
 ## Configuration
@@ -59,7 +59,7 @@ This will hide the field, but will not hide the title. To hide the title you cou
 
 ### Plugin helper functions
 
-`getModel(modelId)`, `getUpload(uploadId)` and `getFieldValue(formValues, fieldPath)` are functions to use in the plugin. When you have added the DatoCMS readonly token in the general settings of the plugin, you can use these two functions.
+`getModel(modelId)`, `getModelType(itemTypeId)`, `getUpload(uploadId)` and `getFieldValue(formValues, fieldPath)` are functions to use in the plugin. When you have added the DatoCMS readonly token in the general settings of the plugin, you can use these functions.
 
 For example: When there is an `uploadId` you can use this function to get all data for this upload.
 ```js
@@ -71,6 +71,12 @@ For example: When there is an `modelId` you can use this function to get all dat
 ```js
 const model = await getModel(modelId)
 return model.title
+```
+
+For example: When there is an `itemTypeId` you can use this function to get the model schema (item type).
+```js
+const itemType = await getModelType(itemTypeId)
+return itemType.name
 ```
 
 For example: To get the value of a field you can use the datoCmsPlugin variable.

--- a/src/lib/executeComputedCode.ts
+++ b/src/lib/executeComputedCode.ts
@@ -5,6 +5,7 @@ import { buildClient } from '@datocms/cma-client-browser'
 interface Variables {
   getUpload: (uploadId: string) => any
   getModel: (modelId: string) => any
+  getModelType: (itemTypeId: string) => any
   getFieldValue: (object: object, fieldName: string) => any
   changedField: string | undefined
   locale: string
@@ -44,6 +45,15 @@ export default async function executeComputedCode(
     return datoClient.items.find(modelId)
   }
 
+  function getModelType(itemTypeId: string) {
+    if (!datoClient) {
+      console.error(accessTokenError)
+      return accessTokenError
+    }
+
+    return datoClient.itemTypes.find(itemTypeId)
+  }
+
   let thisBlock = null
   const fieldPath = ctx.fieldPath
   const indexOfDot = fieldPath.lastIndexOf('.')
@@ -55,6 +65,7 @@ export default async function executeComputedCode(
   const variables: Variables = {
     getUpload: getUpload,
     getModel: getModel,
+    getModelType: getModelType,
     getFieldValue: getFieldValue,
     changedField: changedField,
     locale: ctx.locale,


### PR DESCRIPTION
Hi

Really useful plugin, thank you for that :slightly_smiling_face: 
We have a use case where we need the model/block schema to compute the value, so I'm trying to expose the underlying sdk function.

The `getModel` naming was already taken for what should probably have been called `getRecord`, so I went with `getModelType`. Let me know if you want something else.

