### PR TITLE
Improve dark mode support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@uiw/react-codemirror": "^4.21.9",
-        "datocms-plugin-sdk": "^0.7.14",
-        "datocms-react-ui": "^0.7.14",
+        "datocms-plugin-sdk": "^2.2.2",
+        "datocms-react-ui": "^2.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^4.9.5"
@@ -33,9 +33,6 @@
         "prettier": "^3.0.1",
         "react-scripts": "^5.0.1",
         "ts-jest": "^29.1.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2777,17 +2774,57 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.4.tgz",
-      "integrity": "sha512-21hhDEPOiWkGp0Ys4Wi6Neriah7HweToKra626CIK712B5m9qkdz54OP9gVldUg+URnBTpv/j/bi/skmGdstXQ==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.3.1"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -5124,7 +5161,8 @@
     "node_modules/array-flatten": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.6",
@@ -6979,12 +7017,15 @@
       }
     },
     "node_modules/datocms-plugin-sdk": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/datocms-plugin-sdk/-/datocms-plugin-sdk-0.7.14.tgz",
-      "integrity": "sha512-T5l2AvpAQnS9qgs+PcIX3Ay5MgIUXO+004S6RrLoTP6KKg13EIzb2BMc5FLGJWFzDBRiu3oeQOfAcUq53up4iQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/datocms-plugin-sdk/-/datocms-plugin-sdk-2.2.2.tgz",
+      "integrity": "sha512-o19tEt+EGwUHqE+mHmu2j6YWVQtNLawtYd2PqfHDB/1/q3kkhziQDOFg2naeHy+xd3RqwYlrJdRBSYZGw3DcUw==",
+      "license": "MIT",
       "dependencies": {
+        "@datocms/cma-client": "*",
         "@types/react": "^17.0.3",
-        "datocms-structured-text-utils": "^2.0.0",
+        "datocms-structured-text-utils": "^5.1.16",
+        "emoji-regex-xs": "*",
         "penpal": "^4.1.1"
       }
     },
@@ -6999,21 +7040,24 @@
       }
     },
     "node_modules/datocms-react-ui": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/datocms-react-ui/-/datocms-react-ui-0.7.14.tgz",
-      "integrity": "sha512-4mao3uUbRjOzysYHT1vfNJD/ASV3Yu5IwGu5l55bHUxADVahTNb3gLDXlQpG9AGSDFFaQlc9mfdcdogocIFGtQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/datocms-react-ui/-/datocms-react-ui-2.2.4.tgz",
+      "integrity": "sha512-eR/CvhUXU16nHFVk33kSliA3B8Mg9ZwBQDTJcgKJP1NHyMiJ4MAMQkliE1z5QgLxFByPfZoUZichTV5EpEB4ew==",
+      "license": "MIT",
       "dependencies": {
+        "@floating-ui/react": "^0.27.16",
         "classnames": "^2.3.1",
-        "datocms-plugin-sdk": "^0.7.14",
+        "datocms-plugin-sdk": "^2.2.2",
         "react-intersection-observer": "^8.31.0",
         "react-select": "^5.2.1",
         "scroll-into-view-if-needed": "^2.2.20"
       }
     },
     "node_modules/datocms-structured-text-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-2.0.4.tgz",
-      "integrity": "sha512-JxDdJaipm3FePOli9s82MRrBDnlPP9GYhqajQJaYEu4V1jwUSZzbVkYVKMfVHUfP0Gh0VSCxPHjAGGAN1nWMJg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-5.1.16.tgz",
+      "integrity": "sha512-BcTB1dLtE5q+59BCb3Yu+IgNW31ivjXe1W6VaZzamtvN6KcACdoUaeCQJbJ7aOI7zz/RAZM2yDr+roN6xfzrKg==",
+      "license": "MIT",
       "dependencies": {
         "array-flatten": "^3.0.0"
       }
@@ -7558,6 +7602,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -17774,6 +17827,12 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@uiw/react-codemirror": "^4.21.9",
-    "datocms-plugin-sdk": "^0.7.14",
-    "datocms-react-ui": "^0.7.14",
+    "datocms-plugin-sdk": "^2.2.2",
+    "datocms-react-ui": "^2.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^4.9.5"

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -5,16 +5,17 @@ import { oneDark } from '@codemirror/theme-one-dark'
 type Props = {
   code: string
   onChange: (value: string) => void
+  colorScheme?: string
 }
 
-export default function CodeEditor({ code, onChange }: Props) {
+export default function CodeEditor({ code, onChange, colorScheme }: Props) {
   return (
     <CodeMirror
       value={code}
       minHeight="200px"
       extensions={[javascript()]}
       onChange={onChange}
-      theme={oneDark}
+      theme={colorScheme === 'dark' ? oneDark : 'light'}
     />
   )
 }

--- a/src/components/RenderResults/RenderResults.module.css
+++ b/src/components/RenderResults/RenderResults.module.css
@@ -1,7 +1,7 @@
 .textarea {
   font-family: var(--base-font-family);
   font-size: var(--font-size-s);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color--border);
   width: 100%;
   box-sizing: border-box;
   min-height: 100px;

--- a/src/entrypoints/FieldExtension/FieldExtension.tsx
+++ b/src/entrypoints/FieldExtension/FieldExtension.tsx
@@ -84,7 +84,11 @@ export default function FieldExtension({ ctx }: Props) {
     <Canvas ctx={ctx}>
       {showCodeEditor && (
         <div className={styles.editorContainer}>
-          <CodeEditor code={codeValue} onChange={setCodeValue} />
+          <CodeEditor
+            code={codeValue}
+            onChange={setCodeValue}
+            colorScheme={ctx.colorScheme}
+          />
 
           <Button
             className={styles.button}

--- a/src/entrypoints/FieldExtensionConfigScreen/FieldExtensionConfigScreen.tsx
+++ b/src/entrypoints/FieldExtensionConfigScreen/FieldExtensionConfigScreen.tsx
@@ -62,6 +62,7 @@ export default function FieldExtensionConfigScreen({ ctx }: Props) {
           <CodeEditor
             code={defaultFunction}
             onChange={handleDefaultFunctionChange}
+            colorScheme={ctx.colorScheme}
           />
           <FieldHint>
             This field always needs a return (i.e. return title)

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -173,7 +173,7 @@ form {
  */
 
 fieldset {
-  border: 1px solid #c0c0c0;
+  border: 1px solid var(--color--border-hover);
   margin: 0 2px;
   padding: 0.35em 0.625em 0.75em;
 }
@@ -330,17 +330,17 @@ button,
 input,
 select,
 textarea {
-  color: #222;
+  color: var(--color--ink);
 }
 
 
 ::-moz-selection {
-  background: #b3d4fc;
+  background: var(--color--highlight--surface);
   text-shadow: none;
 }
 
 ::selection {
-  background: #b3d4fc;
+  background: var(--color--highlight--surface);
   text-shadow: none;
 }
 
@@ -360,7 +360,7 @@ textarea {
 
 .chromeframe {
   margin: 0.2em 0;
-  background: #ccc;
-  color: #000;
+  background: var(--color--surface-muted);
+  color: var(--color--ink);
   padding: 0.2em 0;
 }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -33,7 +33,7 @@ strong {
 pre {
   font-family: var(--monospaced-font-family);
   font-size: var(--font-size-s);
-  background-color: var(--light-bg-color);
+  background-color: var(--color--surface-muted);
   padding: var(--spacing-m);
   margin-bottom: var(--spacing-m);
 }


### PR DESCRIPTION
Updated the plugin to use the current DatoCMS SDK/UI packages and Canvas color tokens so borders, text, selections, and code editor surfaces adapt to the active dashboard theme.

The code editor now follows `ctx.colorScheme` in both field configuration and debug usage, keeping the light editor in light mode and the dark editor in dark mode.

Note: The huge diff is caused by package-lock.json due to the necessary dependencies updates!

<img width="1514" height="1046" alt="10062" src="https://github.com/user-attachments/assets/963297df-bef2-4740-b8b1-576098c6f6d1" />

<img width="1520" height="1030" alt="11728" src="https://github.com/user-attachments/assets/1561879a-d959-4db6-bbdf-5a8aff780c5e" />


